### PR TITLE
Support Ruby 1.8.7

### DIFF
--- a/lib/json-schema/attributes/formats/date_time_v4.rb
+++ b/lib/json-schema/attributes/formats/date_time_v4.rb
@@ -5,7 +5,11 @@ module JSON
     class DateTimeV4Format < FormatAttribute
       def self.validate(current_schema, data, fragments, processor, validator, options = {})
         return unless data.is_a?(String)
-        DateTime.rfc3339(data)
+        begin
+          DateTime.rfc3339(data)
+        rescue NoMethodError
+          Time.iso8601(data)
+        end
       rescue ArgumentError
         error_message = "The property '#{build_fragment(fragments)}' must be a valid RFC3339 date/time string"
         validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors])

--- a/lib/json-schema/attributes/properties.rb
+++ b/lib/json-schema/attributes/properties.rb
@@ -55,6 +55,8 @@ module JSON
           end
         end
 
+        diff = Hash[diff] if diff.is_a?(Array)
+
         if diff.size > 0
           properties = diff.keys.join(', ')
           message = "The property '#{build_fragment(fragments)}' contained undefined properties: '#{properties}'"


### PR DESCRIPTION
- DateTime.rfc3339 was introduced in Ruby 1.9, so for now default to ISO 8601 format (which is almost identical)
- `Hash#select` returns an Array in Ruby 1.8 and a Hash in 1.9. Updated here to always return a Hash.
